### PR TITLE
Fixed typing issue for python 3.7 and 3.8

### DIFF
--- a/pipewire_python/_utils.py
+++ b/pipewire_python/_utils.py
@@ -2,9 +2,10 @@
 Here we store internal functions, don't expect
 to see something here in documentation html version.
 """
-import subprocess
 import asyncio
 import re
+import subprocess
+from typing import Dict, List
 
 # Loading constants Constants.py
 from ._constants import MESSAGES_ERROR
@@ -49,8 +50,8 @@ def _get_dict_from_stdout(
 
 
 def _update_dict_by_dict(
-    main_dict: dict,
-    secondary_dict: dict,
+    main_dict: Dict,
+    secondary_dict: Dict,
 ):
     """
     Update values of one dictionary with values of another dictionary
@@ -67,7 +68,7 @@ def _drop_keys_with_none_values(main_dict: dict):
 
 
 def _generate_command_by_dict(
-    mydict: dict,
+    mydict: Dict,
     # Debug
     verbose: bool = False,
 ):
@@ -85,7 +86,7 @@ def _generate_command_by_dict(
 
 
 def _execute_shell_command(
-    command: list[str],
+    command: List[str],
     timeout: int = -1,  # *default= no limit
     # Debug
     verbose: bool = False,


### PR DESCRIPTION
The current version fails to launch:

``` 
In [1]: from pipewire_python.controller import Controller
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Input In [1], in <cell line: 1>()
----> 1 from pipewire_python.controller import Controller

File ~/.local/lib/python3.8/site-packages/pipewire_python/controller.py:11, in <module>
      8 import warnings
     10 # Loading internal functions
---> 11 from ._utils import (
     12     _drop_keys_with_none_values,
     13     _execute_shell_command,
     14     _filter_by_type,
     15     _generate_command_by_dict,
     16     _generate_dict_interfaces,
     17     _generate_dict_list_targets,
     18     _get_dict_from_stdout,
     19     _print_std,
     20     _update_dict_by_dict,
     21 )
     23 # Loading constants Constants.py
     24 from ._constants import MESSAGES_ERROR, RECOMMENDED_FORMATS, RECOMMENDED_RATES

File ~/.local/lib/python3.8/site-packages/pipewire_python/_utils.py:88, in <module>
     83     # return values
     84     return array_command
     87 def _execute_shell_command(
---> 88     command: list[str],
     89     timeout: int = -1,  # *default= no limit
     90     # Debug
     91     verbose: bool = False,
     92 ):
     93     """
     94     Execute command on terminal via subprocess
     95 
   (...)
    102         - stderr (str): terminal response to the command
    103     """
    104     # Create subprocess
    105     # NO-RESOURCE-ALLOCATING
    106     # terminal_subprocess = subprocess.Popen(
    107     #     command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT  # Example ['ls ','l']
    108     # )

TypeError: 'type' object is not subscriptable
```

Also all the test fail with the same error. This PR should fix it by using `List` from the Typing module.

Support for `list[]` was added on python3.9: https://docs.python.org/3/whatsnew/3.9.html#type-hinting-generics-in-standard-collections

Tested on python3.7, 3.8  and 3.10
