### PR TITLE
Improvements to Linking with `pw-link` -- Moving to Link "Groups"

### DIFF
--- a/pipewire_python/link.py
+++ b/pipewire_python/link.py
@@ -76,6 +76,9 @@ PW_LINK_COMMAND = "pw-link"
 class InvalidLink(ValueError):
     """Invalid link configuration."""
 
+class FailedToLinkPorts(ValueError):
+    """Failed to Link the Specified Ports."""
+
 
 class PortType(Enum):
     """Pipewire Channel Type - Input or Output."""
@@ -137,7 +140,9 @@ class Port:
     def connect(self, other: "Port") -> None:
         """Connect this channel to another channel."""
         args = self._join_arguments(other=other, message="Cannot connect an {} to another {}.")
-        _ = _execute_shell_command(args)
+        stdout, _ = _execute_shell_command(args)
+        if b"failed to link ports" in stdout:
+            raise FailedToLinkPorts(stdout)
 
     def disconnect(self, other: "Port") -> None:
         """Disconnect this channel from another."""

--- a/pipewire_python/link.py
+++ b/pipewire_python/link.py
@@ -344,15 +344,15 @@ class Link:
 
     def disconnect(self):
         """Disconnect the Link."""
-        for input in self.inputs:
-            for output in self.outputs:
-                input.disconnect(output)
+        for input_obj in self.inputs:
+            for output_obj in self.outputs:
+                input_obj.disconnect(output_obj)
 
     def reconnect(self):
         """Reconnect the Link if Previously Disconnected."""
-        for input in self.inputs:
-            for output in self.outputs:
-                input.connect(output)
+        for input_obj in self.inputs:
+            for output_obj in self.outputs:
+                input_obj.connect(output_obj)
 
 
 @dataclass

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -8,16 +8,17 @@ def test_list():
     inputs=list_inputs()
     if len(inputs) == 0:
         return # No inputs, no point in testing
-    
+
     assert list_inputs()
     assert list_outputs()
+    assert list_links()
 
     # Disconnect everything
     for in_dev in list_inputs():
         for out_dev in list_outputs():
             if isinstance(in_dev, StereoInput) and isinstance(out_dev, StereoOutput):
                 in_dev.disconnect(out_dev)
-    
+
     assert len(list_links()) == 0
 
 def test_connect_disconnect():
@@ -29,7 +30,7 @@ def test_connect_disconnect():
         for out_dev in list_outputs():
             if isinstance(in_dev, StereoInput) and isinstance(out_dev, StereoOutput):
                 links.append(in_dev.connect(out_dev))
-    
+
     # Disconnect Afterwards
     for link in links:
         link.disconnect()

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,5 +1,6 @@
 from pipewire_python.link import (
-    list_inputs, list_outputs, list_links, StereoInput, StereoOutput
+    list_inputs, list_outputs, list_links, list_link_groups,
+    StereoInput, StereoOutput
 )
 
 
@@ -12,6 +13,7 @@ def test_list():
     assert list_inputs()
     assert list_outputs()
     assert list_links()
+    assert list_link_groups()
 
     # Disconnect everything
     for in_dev in list_inputs():


### PR DESCRIPTION
## Changes

* I realized that there were some fundamentally incorrect assumptions in some of the previous work I'd provided in relation to the stereo links. This pull request addresses some of those incorrect interpretations of links to provide more meaningful representation.
* This removes "stereo" links and replaces them with links and link "groups," more appropriately representing the links as they are presented from the `pw-link` tooling.